### PR TITLE
Validator fix

### DIFF
--- a/src/Validators/AddressLookupValidator.php
+++ b/src/Validators/AddressLookupValidator.php
@@ -39,7 +39,7 @@ class AddressLookupValidator
         $validation = $this->validator->make($data, $this->rules);
 
         if ($validation->fails()) {
-			throw new ValidationException($validation->errors(),new JsonResponse($validation->errors(), 422));
+			throw new ValidationException($validation,new JsonResponse($validation->errors(), 422));
         }
     }
 }

--- a/src/Validators/AddressLookupValidator.php
+++ b/src/Validators/AddressLookupValidator.php
@@ -39,7 +39,7 @@ class AddressLookupValidator
         $validation = $this->validator->make($data, $this->rules);
 
         if ($validation->fails()) {
-            throw new ValidationException($validation->errors());
+			throw new ValidationException($validation->errors(),new JsonResponse($validation->errors(), 422));
         }
     }
 }


### PR DESCRIPTION
Bug fix in AddressLookUpValidator

This fix an error when the address lookup input is not valid. Currently if input is not valid you get the next error: Call to undefined method Illuminate\Support\MessageBag::errors()
