### PR TITLE
Allow lowercase letters in the postcode validator

### DIFF
--- a/src/Validators/AddressLookupValidator.php
+++ b/src/Validators/AddressLookupValidator.php
@@ -9,7 +9,7 @@ use Illuminate\Validation\ValidationException;
 class AddressLookupValidator
 {
     protected const RULES = [
-        'postcode' => ['required', 'regex:/^[1-9]{1}[0-9]{3}[A-Z]{2}$/'],
+        'postcode' => ['required', 'regex:/^[1-9]{1}[0-9]{3}[A-Za-z]{2}$/'],
         'houseNumber' => ['required', 'integer', 'between:0,99999'],
         'houseNumberAddition' => ['sometimes', 'string']
     ];


### PR DESCRIPTION
When our users entered a postcode with lowercase letters, the package returned a validation error. The API endpoint does support lowercase letters, so let's support them in the package too.