### PR TITLE
Change base_uri to https://api.postcode.eu/nl/v1

### DIFF
--- a/src/Services/AddressLookup.php
+++ b/src/Services/AddressLookup.php
@@ -18,7 +18,7 @@ use function sprintf;
 
 class AddressLookup
 {
-    private const BASE_URI = 'https://api.postcode.nl/rest/addresses';
+    private const BASE_URI = 'https://api.postcode.eu/nl/v1/addresses';
 
     /**
      * @var AddressLookupValidator


### PR DESCRIPTION
This PR changes the BASE_URI https://api.postcode.nl/rest into https://api.postcode.eu/nl/v1 which is the new endpoint according to https://developer.postcode.eu/documentation/rest-json-endpoint